### PR TITLE
update README links to Julia and Rust

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,4 +86,4 @@ series = {SC '22}
 }
 ```
 
-Both [Julia bindings](https://github.com/wsmoses/Enzyme.jl) and [Rust bindings](https://github.com/rust-ml/oxide-enzyme) are available for Enzyme.
+Both [Julia bindings](https://github.com/EnzymeAD/Enzyme.jl#readme) and [Rust bindings](https://github.com/EnzymeAD/rust#readme) are available for Enzyme.


### PR DESCRIPTION
Both projects have moved, so point to their current location.